### PR TITLE
Support multiple log levels

### DIFF
--- a/fw/logger.go
+++ b/fw/logger.go
@@ -1,7 +1,33 @@
 package fw
 
+type LogLevel int
+
+const (
+	LogFatal LogLevel = iota
+	LogError
+	LogWarn
+	LogInfo
+	LogDebug
+	LogTrace
+	LogOff
+)
+
+type LogLevelName string
+
+const (
+	LogFatalName LogLevelName = "Fatal"
+	LogErrorName LogLevelName = "Error"
+	LogWarnName  LogLevelName = "Warn"
+	LogInfoName  LogLevelName = "Info"
+	LogDebugName LogLevelName = "Debug"
+	LogTraceName LogLevelName = "Trace"
+)
+
 type Logger interface {
-	Info(info string)
+	Fatal(message string)
 	Error(err error)
-	Crash(err error)
+	Warn(message string)
+	Info(message string)
+	Debug(message string)
+	Trace(message string)
 }

--- a/mdtest/logger.go
+++ b/mdtest/logger.go
@@ -5,27 +5,52 @@ import "github.com/byliuyang/app/fw"
 var _ fw.Logger = (*LoggerFake)(nil)
 
 type LoggerFake struct {
-	Infos   []string
-	Errors  []error
-	Crashes []error
+	FatalMessages []string
+	Errors        []error
+	WarnMessages  []string
+	InfoMessages  []string
+	DebugMessages []string
+	TraceMessages []string
 }
 
-func (l *LoggerFake) Info(info string) {
-	l.Infos = append(l.Infos, info)
+func (l *LoggerFake) Fatal(message string) {
+	l.FatalMessages = append(l.FatalMessages, message)
 }
 
 func (l *LoggerFake) Error(err error) {
 	l.Errors = append(l.Errors, err)
 }
 
-func (l *LoggerFake) Crash(err error) {
-	l.Crashes = append(l.Crashes, err)
+func (l *LoggerFake) Warn(message string) {
+	l.WarnMessages = append(l.WarnMessages, message)
 }
 
-func NewLoggerFake() LoggerFake {
+func (l *LoggerFake) Info(message string) {
+	l.InfoMessages = append(l.InfoMessages, message)
+}
+
+func (l *LoggerFake) Debug(message string) {
+	l.DebugMessages = append(l.DebugMessages, message)
+}
+
+func (l *LoggerFake) Trace(message string) {
+	l.TraceMessages = append(l.TraceMessages, message)
+}
+
+func NewLoggerFake(
+	fatalMessages []string,
+	errors []error,
+	warnMessages []string,
+	infoMessages []string,
+	debugMessages []string,
+	traceMessages []string,
+) LoggerFake {
 	return LoggerFake{
-		Infos:   make([]string, 0),
-		Errors:  make([]error, 0),
-		Crashes: make([]error, 0),
+		FatalMessages: fatalMessages,
+		Errors:        errors,
+		WarnMessages:  warnMessages,
+		InfoMessages:  infoMessages,
+		DebugMessages: debugMessages,
+		TraceMessages: traceMessages,
 	}
 }

--- a/modern/mdlogger/local.go
+++ b/modern/mdlogger/local.go
@@ -9,7 +9,7 @@ import (
 
 var _ fw.Logger = (*Local)(nil)
 
-const datetimeFormat  = "2006-01-02 15:04:05"
+const datetimeFormat = "2006-01-02 15:04:05"
 
 type Local struct {
 	prefix string

--- a/modern/mdlogger/local.go
+++ b/modern/mdlogger/local.go
@@ -1,26 +1,125 @@
 package mdlogger
 
 import (
-	"log"
+	"fmt"
+	"runtime"
 
 	"github.com/byliuyang/app/fw"
 )
 
+var _ fw.Logger = (*Local)(nil)
+
+const datetimeFormat  = "2006-01-02 15:04:05"
+
 type Local struct {
+	prefix string
+	timer  fw.Timer
+	level  fw.LogLevel
 }
 
-func (Local) Error(err error) {
-	log.Println(err.Error())
+func (local Local) Fatal(message string) {
+	if local.levelAboveFatal() {
+		return
+	}
+	local.log(fw.LogFatalName, message)
 }
 
-func (Local) Info(info string) {
-	log.Println(info)
+func (local Local) Error(err error) {
+	if local.levelAboveError() {
+		return
+	}
+	local.log(fw.LogFatalName, fmt.Sprintf("%v", err))
 }
 
-func (Local) Crash(err error) {
-	log.Fatal(err)
+func (local Local) Warn(message string) {
+	if local.levelAboveWarn() {
+		return
+	}
+	local.log(fw.LogWarnName, message)
 }
 
-func NewLocal() fw.Logger {
-	return Local{}
+func (local Local) Info(message string) {
+	if local.levelAboveInfo() {
+		return
+	}
+	local.log(fw.LogInfoName, message)
+}
+
+func (local Local) Debug(message string) {
+	if local.levelAboveDebug() {
+		return
+	}
+	local.log(fw.LogDebugName, message)
+}
+
+func (local Local) Trace(message string) {
+	if local.levelAboveTrace() {
+		return
+	}
+	local.log(fw.LogTraceName, message)
+}
+
+func (local Local) log(level fw.LogLevelName, message string) {
+	now := local.timer.Now().UTC().Format(datetimeFormat)
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		fmt.Printf("[%s] [%s] %s %s\n", local.prefix, level, now, message)
+		return
+	}
+	fmt.Printf(
+		"[%s] [%s] %s line %d at %s %s\n",
+		local.prefix,
+		level,
+		now,
+		line,
+		file,
+		message,
+	)
+}
+
+func (local Local) levelAboveFatal() bool {
+	return local.level == fw.LogOff
+}
+
+func (local Local) levelAboveError() bool {
+	if local.levelAboveFatal() {
+		return true
+	}
+	return local.level == fw.LogFatal
+}
+
+func (local Local) levelAboveWarn() bool {
+	if local.levelAboveError() {
+		return true
+	}
+	return local.level == fw.LogError
+}
+
+func (local Local) levelAboveInfo() bool {
+	if local.levelAboveWarn() {
+		return true
+	}
+	return local.level == fw.LogWarn
+}
+
+func (local Local) levelAboveDebug() bool {
+	if local.levelAboveInfo() {
+		return true
+	}
+	return local.level == fw.LogInfo
+}
+
+func (local Local) levelAboveTrace() bool {
+	if local.levelAboveDebug() {
+		return true
+	}
+	return local.level == fw.LogDebug
+}
+
+func NewLocal(prefix string, timer fw.Timer, level fw.LogLevel) Local {
+	return Local{
+		prefix: prefix,
+		timer:  timer,
+		level:  level,
+	}
 }

--- a/modern/mdlogger/local_test.go
+++ b/modern/mdlogger/local_test.go
@@ -1,0 +1,653 @@
+package mdlogger
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/byliuyang/app/fw"
+	"github.com/byliuyang/app/mdtest"
+)
+
+func TestLocal_Fatal(t *testing.T) {
+	testCases := []struct {
+		name           string
+		logLevel       fw.LogLevel
+		now            string
+		prefix         string
+		messages       []string
+		callers        []fw.Caller
+		expectedOutput string
+	}{
+		{
+			name:           "logging disabled",
+			logLevel:       fw.LogOff,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:     "log fatal message",
+			logLevel: fw.LogFatal,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message 1", "message 2"},
+			callers: []fw.Caller{{}, {}, {
+				FullFilename: "app/test.go",
+				LineNumber:   10,
+			}},
+			expectedOutput: `[Prefix] [Fatal] 2020-01-04 10:20:04 line 10 at app/test.go message 1
+[Prefix] [Fatal] 2020-01-04 10:20:04 line 10 at app/test.go message 2
+`,
+		},
+		{
+			name:     "log error message",
+			logLevel: fw.LogError,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Fatal] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log warn message",
+			logLevel: fw.LogWarn,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Fatal] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log info message",
+			logLevel: fw.LogInfo,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Fatal] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log debug message",
+			logLevel: fw.LogDebug,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Fatal] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log trace message",
+			logLevel: fw.LogTrace,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Fatal] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, testCase.now)
+			mdtest.Equal(t, nil, err)
+			timer := mdtest.NewTimerFake(now)
+
+			programRuntime, err := mdtest.NewProgramRuntimeFake(testCase.callers)
+			mdtest.Equal(t, nil, err)
+
+			var buf bytes.Buffer
+			logger := NewLocal(
+				testCase.prefix,
+				testCase.logLevel,
+				&buf,
+				timer,
+				programRuntime,
+			)
+
+			for _, message := range testCase.messages {
+				logger.Fatal(message)
+			}
+			gotOutput := buf.String()
+			mdtest.Equal(t, testCase.expectedOutput, gotOutput)
+		})
+	}
+}
+
+func TestLocal_Error(t *testing.T) {
+	testCases := []struct {
+		name           string
+		logLevel       fw.LogLevel
+		now            string
+		prefix         string
+		messages       []string
+		callers        []fw.Caller
+		expectedOutput string
+	}{
+		{
+			name:           "logging disabled",
+			logLevel:       fw.LogOff,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log fatal message",
+			logLevel:       fw.LogFatal,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:     "log error message",
+			logLevel: fw.LogError,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message 1", "message 2"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Error] 2020-01-04 10:20:04 line 10 at app/test.go message 1
+[Prefix] [Error] 2020-01-04 10:20:04 line 10 at app/test.go message 2
+`,
+		},
+		{
+			name:     "log warn message",
+			logLevel: fw.LogWarn,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Error] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log info message",
+			logLevel: fw.LogInfo,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Error] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log debug message",
+			logLevel: fw.LogDebug,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Error] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log trace message",
+			logLevel: fw.LogTrace,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Error] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, testCase.now)
+			mdtest.Equal(t, nil, err)
+			timer := mdtest.NewTimerFake(now)
+
+			programRuntime, err := mdtest.NewProgramRuntimeFake(testCase.callers)
+			mdtest.Equal(t, nil, err)
+
+			var buf bytes.Buffer
+			logger := NewLocal(
+				testCase.prefix,
+				testCase.logLevel,
+				&buf,
+				timer,
+				programRuntime,
+			)
+
+			for _, message := range testCase.messages {
+				logger.Error(errors.New(message))
+			}
+			gotOutput := buf.String()
+			mdtest.Equal(t, testCase.expectedOutput, gotOutput)
+		})
+	}
+}
+
+func TestLocal_Warn(t *testing.T) {
+	testCases := []struct {
+		name           string
+		logLevel       fw.LogLevel
+		now            string
+		prefix         string
+		messages       []string
+		callers        []fw.Caller
+		expectedOutput string
+	}{
+		{
+			name:           "logging disabled",
+			logLevel:       fw.LogOff,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log fatal message",
+			logLevel:       fw.LogFatal,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log error message",
+			logLevel:       fw.LogError,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:     "log warn message",
+			logLevel: fw.LogWarn,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message 1", "message 2"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Warn] 2020-01-04 10:20:04 line 10 at app/test.go message 1
+[Prefix] [Warn] 2020-01-04 10:20:04 line 10 at app/test.go message 2
+`,
+		},
+		{
+			name:     "log info message",
+			logLevel: fw.LogInfo,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Warn] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log debug message",
+			logLevel: fw.LogDebug,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Warn] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log trace message",
+			logLevel: fw.LogTrace,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Warn] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, testCase.now)
+			mdtest.Equal(t, nil, err)
+			timer := mdtest.NewTimerFake(now)
+
+			programRuntime, err := mdtest.NewProgramRuntimeFake(testCase.callers)
+			mdtest.Equal(t, nil, err)
+
+			var buf bytes.Buffer
+			logger := NewLocal(
+				testCase.prefix,
+				testCase.logLevel,
+				&buf,
+				timer,
+				programRuntime,
+			)
+
+			for _, message := range testCase.messages {
+				logger.Warn(message)
+			}
+			gotOutput := buf.String()
+			mdtest.Equal(t, testCase.expectedOutput, gotOutput)
+		})
+	}
+}
+
+func TestLocal_Info(t *testing.T) {
+	testCases := []struct {
+		name           string
+		logLevel       fw.LogLevel
+		now            string
+		prefix         string
+		messages       []string
+		callers        []fw.Caller
+		expectedOutput string
+	}{
+		{
+			name:           "logging disabled",
+			logLevel:       fw.LogOff,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log fatal message",
+			logLevel:       fw.LogFatal,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log error message",
+			logLevel:       fw.LogError,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:           "log warn message",
+			logLevel:       fw.LogWarn,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:     "log info message",
+			logLevel: fw.LogInfo,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message 1", "message 2"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Info] 2020-01-04 10:20:04 line 10 at app/test.go message 1
+[Prefix] [Info] 2020-01-04 10:20:04 line 10 at app/test.go message 2
+`,
+		},
+		{
+			name:     "log debug message",
+			logLevel: fw.LogDebug,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Info] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+		{
+			name:     "log trace message",
+			logLevel: fw.LogTrace,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Info] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, testCase.now)
+			mdtest.Equal(t, nil, err)
+			timer := mdtest.NewTimerFake(now)
+
+			programRuntime, err := mdtest.NewProgramRuntimeFake(testCase.callers)
+			mdtest.Equal(t, nil, err)
+
+			var buf bytes.Buffer
+			logger := NewLocal(
+				testCase.prefix,
+				testCase.logLevel,
+				&buf,
+				timer,
+				programRuntime,
+			)
+
+			for _, message := range testCase.messages {
+				logger.Info(message)
+			}
+			gotOutput := buf.String()
+			mdtest.Equal(t, testCase.expectedOutput, gotOutput)
+		})
+	}
+}
+
+func TestLocal_Debug(t *testing.T) {
+	testCases := []struct {
+		name           string
+		logLevel       fw.LogLevel
+		now            string
+		prefix         string
+		messages       []string
+		callers        []fw.Caller
+		expectedOutput string
+	}{
+		{
+			name:           "logging disabled",
+			logLevel:       fw.LogOff,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log fatal message",
+			logLevel:       fw.LogFatal,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log error message",
+			logLevel:       fw.LogError,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:           "log warn message",
+			logLevel:       fw.LogWarn,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:           "log info message",
+			logLevel:       fw.LogInfo,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:     "log debug message",
+			logLevel: fw.LogDebug,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message 1", "message 2"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Debug] 2020-01-04 10:20:04 line 10 at app/test.go message 1
+[Prefix] [Debug] 2020-01-04 10:20:04 line 10 at app/test.go message 2
+`,
+		},
+		{
+			name:     "log trace message",
+			logLevel: fw.LogTrace,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Debug] 2020-01-04 10:20:04 line 10 at app/test.go message
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, testCase.now)
+			mdtest.Equal(t, nil, err)
+			timer := mdtest.NewTimerFake(now)
+
+			programRuntime, err := mdtest.NewProgramRuntimeFake(testCase.callers)
+			mdtest.Equal(t, nil, err)
+
+			var buf bytes.Buffer
+			logger := NewLocal(
+				testCase.prefix,
+				testCase.logLevel,
+				&buf,
+				timer,
+				programRuntime,
+			)
+
+			for _, message := range testCase.messages {
+				logger.Debug(message)
+			}
+			gotOutput := buf.String()
+			mdtest.Equal(t, testCase.expectedOutput, gotOutput)
+		})
+	}
+}
+
+func TestLocal_Trace(t *testing.T) {
+	testCases := []struct {
+		name           string
+		logLevel       fw.LogLevel
+		now            string
+		prefix         string
+		messages       []string
+		callers        []fw.Caller
+		expectedOutput string
+	}{
+		{
+			name:           "logging disabled",
+			logLevel:       fw.LogOff,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log fatal message",
+			logLevel:       fw.LogFatal,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{},
+			callers:        []fw.Caller{},
+			expectedOutput: "",
+		},
+		{
+			name:           "log error message",
+			logLevel:       fw.LogError,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:           "log warn message",
+			logLevel:       fw.LogWarn,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:           "log info message",
+			logLevel:       fw.LogInfo,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:           "log debug message",
+			logLevel:       fw.LogDebug,
+			now:            "2020-01-04T10:20:04-00:00",
+			prefix:         "Prefix",
+			messages:       []string{"message"},
+			callers:        []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: "",
+		},
+		{
+			name:     "log trace message",
+			logLevel: fw.LogTrace,
+			now:      "2020-01-04T10:20:04-00:00",
+			prefix:   "Prefix",
+			messages: []string{"message 1", "message 2"},
+			callers:  []fw.Caller{{}, {}, {FullFilename: "app/test.go", LineNumber: 10}},
+			expectedOutput: `[Prefix] [Trace] 2020-01-04 10:20:04 line 10 at app/test.go message 1
+[Prefix] [Trace] 2020-01-04 10:20:04 line 10 at app/test.go message 2
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, testCase.now)
+			mdtest.Equal(t, nil, err)
+			timer := mdtest.NewTimerFake(now)
+
+			programRuntime, err := mdtest.NewProgramRuntimeFake(testCase.callers)
+			mdtest.Equal(t, nil, err)
+
+			var buf bytes.Buffer
+			logger := NewLocal(
+				testCase.prefix,
+				testCase.logLevel,
+				&buf,
+				timer,
+				programRuntime,
+			)
+
+			for _, message := range testCase.messages {
+				logger.Trace(message)
+			}
+			gotOutput := buf.String()
+			mdtest.Equal(t, testCase.expectedOutput, gotOutput)
+		})
+	}
+}


### PR DESCRIPTION
We want to capture every last detail we can because this might prove useful during troubleshooting or auditing the system. 

On the other hand, all of that logging consumes resources. It can eat up disk space, overload people reading the logs, and even start to slow down the production code.

Logging requires either a balance or a way to get both the proverbial signal and the noise. Logging levels makes the situation configurable on the fly.

<img width="1448" alt="Screen Shot 2020-01-03 at 10 19 59 PM" src="https://user-images.githubusercontent.com/3537801/71762232-ecfec580-2e81-11ea-8c6b-735ac64d5011.png">


https://short-d.com/r/logging