### PR TITLE
Add I/O standard input and standard output definitions

### DIFF
--- a/fw/io.go
+++ b/fw/io.go
@@ -1,0 +1,6 @@
+package fw
+
+import "io"
+
+type StdIn io.Reader
+type StdOut io.Writer


### PR DESCRIPTION
It's difficult to unit test the code reading from standard input or writing to standard output. Abstracting out standard input and output enables testing the core business logic in isolation.