### PR TITLE
Add program runtime interface

### DIFF
--- a/fw/runtime.go
+++ b/fw/runtime.go
@@ -1,0 +1,10 @@
+package fw
+
+type Caller struct {
+	FullFilename string
+	LineNumber   int
+}
+
+type ProgramRuntime interface {
+	Caller(numLevelsUp int) (Caller, error)
+}

--- a/mdtest/runtime.go
+++ b/mdtest/runtime.go
@@ -1,0 +1,28 @@
+package mdtest
+
+import (
+	"errors"
+
+	"github.com/byliuyang/app/fw"
+)
+
+var _ fw.ProgramRuntime = (*ProgramRuntimeFake)(nil)
+
+type ProgramRuntimeFake struct {
+	callers []fw.Caller
+}
+
+func (p ProgramRuntimeFake) Caller(numLevelsUp int) (fw.Caller, error) {
+
+	if numLevelsUp > len(p.callers) {
+		return fw.Caller{}, errors.New("level of range")
+	}
+	return p.callers[numLevelsUp], nil
+}
+
+func NewProgramRuntimeFake(callers []fw.Caller) (ProgramRuntimeFake, error) {
+	if callers == nil {
+		return ProgramRuntimeFake{}, errors.New("no caller")
+	}
+	return ProgramRuntimeFake{callers: callers}, nil
+}


### PR DESCRIPTION
It's difficult to unit test the code accessing Go runtime information and program caller. Abstracting out program runtime enables testing the core business logic in isolation