### PR TITLE
Fixed bug: ProgramRuntimeFake does not implement fw.ProgramRuntime

### DIFF
--- a/mdtest/runtime.go
+++ b/mdtest/runtime.go
@@ -2,7 +2,6 @@ package mdtest
 
 import (
 	"errors"
-
 	"github.com/short-d/app/fw"
 )
 
@@ -18,6 +17,9 @@ func (p ProgramRuntimeFake) Caller(numLevelsUp int) (fw.Caller, error) {
 		return fw.Caller{}, errors.New("level of range")
 	}
 	return p.callers[numLevelsUp], nil
+}
+
+func (p ProgramRuntimeFake) LockOSThread() {
 }
 
 func NewProgramRuntimeFake(callers []fw.Caller) (ProgramRuntimeFake, error) {


### PR DESCRIPTION
This fixes the bug:
```
# github.com/short-d/app/mdtest [github.com/short-d/app/mdtest.test]
mdtest/runtime.go:9:5: cannot use (*ProgramRuntimeFake)(nil) (type *ProgramRuntimeFake) as type fw.ProgramRuntime in assignment:
	*ProgramRuntimeFake does not implement fw.ProgramRuntime (missing LockOSThread method)
# github.com/short-d/app/mdtest
mdtest/runtime.go:9:5: cannot use (*ProgramRuntimeFake)(nil) (type *ProgramRuntimeFake) as type fw.ProgramRuntime in assignment:
	*ProgramRuntimeFake does not implement fw.ProgramRuntime (missing LockOSThread method)
``` 

The regression has caused by https://github.com/short-d/app/pull/61 and it is definitely due to lack of CI/CD (testing)