### PR TITLE
Move TemplateFake, EmailSenderFake into md5test

### DIFF
--- a/mdtest/email.go
+++ b/mdtest/email.go
@@ -1,0 +1,32 @@
+package mdtest
+
+import "github.com/short-d/app/fw"
+
+var _ fw.EmailSender = (*EmailSenderFake)(nil)
+
+type EmailSenderFake struct {
+	sendError error
+	sentEmail fw.Email
+}
+
+func (e *EmailSenderFake) SendEmail(email fw.Email) error {
+	if e.sendError != nil {
+		return e.sendError
+	}
+
+	e.sentEmail = email
+
+	return nil
+}
+
+func (e EmailSenderFake) GetSentEmail() fw.Email {
+	return e.sentEmail
+}
+
+func (e *EmailSenderFake) SetSendError(err error) {
+	e.sendError = err
+}
+
+func NewEmailSenderFake() EmailSenderFake {
+	return EmailSenderFake{}
+}

--- a/mdtest/email.go
+++ b/mdtest/email.go
@@ -15,7 +15,6 @@ func (e *EmailSenderFake) SendEmail(email fw.Email) error {
 	}
 
 	e.sentEmail = email
-
 	return nil
 }
 

--- a/mdtest/template.go
+++ b/mdtest/template.go
@@ -1,0 +1,19 @@
+package mdtest
+
+import "github.com/short-d/app/fw"
+
+var _ fw.Template = (*TemplateFake)(nil)
+
+type TemplateFake struct {
+	content string
+}
+
+func (t TemplateFake) Render(renderTemplate string, includeTemplates []string, data interface{}) (string, error) {
+	return t.content, nil
+}
+
+func NewTemplateFake(content string) TemplateFake {
+	return TemplateFake{
+		content: content,
+	}
+}


### PR DESCRIPTION
This PR adds `Template` and `EmailSender` mock implementations in tests, in order to encourage reuse described here https://github.com/short-d/kgs/issues/55 