### PR TITLE
Fix metrics tags being accidentally concatenated issue

### DIFF
--- a/modern/mdmetrics/datadog.go
+++ b/modern/mdmetrics/datadog.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/short-d/app/fw"
@@ -97,20 +96,20 @@ func (d DataDog) requestBody(
 						point,
 					},
 				},
-				Tags: []string{d.dataDogTags(tags)},
+				Tags: d.dataDogTags(tags),
 			},
 		},
 	}
 }
 
-func (d DataDog) dataDogTags(tags map[string]string) string {
+func (d DataDog) dataDogTags(tags map[string]string) []string {
 	var tagsList []string
 
 	for key, val := range tags {
 		pair := fmt.Sprintf("%s:%s", key, val)
 		tagsList = append(tagsList, pair)
 	}
-	return strings.Join(tagsList, ",")
+	return tagsList
 }
 
 func (d DataDog) authHeaders() map[string]string {


### PR DESCRIPTION
Tags for Datadog are concatenated into 1 tag. This prevent business owner from creating dashboard by filtering through individual tag.
<img width="734" alt="Screen Shot 2020-04-16 at 9 22 31 PM" src="https://user-images.githubusercontent.com/3537801/79531969-ac8a1880-8028-11ea-83b6-0ccd3b7e5e2f.png">

Tags are now individually queryable. 
<img width="389" alt="Screen Shot 2020-04-16 at 9 22 37 PM" src="https://user-images.githubusercontent.com/3537801/79531973-b01d9f80-8028-11ea-9ce7-d9bead2e63ae.png">
