### PR TITLE
Fix route handler closure bug

### DIFF
--- a/fw/service/routing.go
+++ b/fw/service/routing.go
@@ -1,11 +1,8 @@
 package service
 
 import (
-	"github.com/short-d/app/fw/io"
 	"github.com/short-d/app/fw/logger"
 	"github.com/short-d/app/fw/router"
-	"github.com/short-d/app/fw/runtime"
-	"github.com/short-d/app/fw/timer"
 	"github.com/short-d/app/fw/web"
 )
 
@@ -62,31 +59,5 @@ func NewRouting(logger logger.Logger, routes []router.Route) Routing {
 	return Routing{
 		logger:    logger,
 		webServer: &server,
-	}
-}
-
-type RoutingBuilder struct {
-	logger logger.Logger
-	routes []router.Route
-}
-
-func (r *RoutingBuilder) Routes(routes []router.Route) *RoutingBuilder {
-	r.routes = routes
-	return r
-}
-
-func (r RoutingBuilder) Build() Routing {
-	return NewRouting(r.logger, r.routes)
-}
-
-func NewRoutingBuilder(name string) *RoutingBuilder {
-	tm := timer.NewSystem()
-	rt := runtime.NewProgram()
-	stdOut := io.NewStdOut()
-	entryRepo := logger.NewLocal(stdOut)
-	lg := logger.NewLogger(name, logger.LogInfo, tm, rt, entryRepo)
-	return &RoutingBuilder{
-		logger: lg,
-		routes: make([]router.Route, 0),
 	}
 }


### PR DESCRIPTION
Router only invokes the handler of the last route due to closure property.

Router now invoke the handler of the matching route.