### PR TITLE
Fix GraphQL request field and return GraphQL errors to API caller

### DIFF
--- a/fw/graphql/client.go
+++ b/fw/graphql/client.go
@@ -2,13 +2,16 @@ package graphql
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/short-d/app/fw/webreq"
 )
 
 type graphQLResponse struct {
-	Data interface{} `json:"data"`
+	Data   interface{}   `json:"data"`
+	Errors []interface{} `json:"errors"`
 }
 
 type Client struct {
@@ -28,6 +31,10 @@ func (c Client) Query(query Query, headers map[string]string, response interface
 	err = c.httpClient.JSON(http.MethodPost, c.root, headers, string(reqBuf), &res)
 	if err != nil {
 		return err
+	}
+
+	if len(res.Errors) > 0 {
+		return errors.New(fmt.Sprintf("%v", res.Errors[0]))
 	}
 
 	resBuf, err := json.Marshal(res.Data)

--- a/fw/graphql/query.go
+++ b/fw/graphql/query.go
@@ -1,6 +1,6 @@
 package graphql
 
 type Query struct {
-	Query     string
-	Variables map[string]interface{}
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
 }


### PR DESCRIPTION
1) GraphQL errors were ignored and returned as success.
2) GraphQL query and variables are not serialized into HTTP request.
