### PR TITLE
Fix table conflicts

### DIFF
--- a/fw/db/dbtest/access.go
+++ b/fw/db/dbtest/access.go
@@ -45,10 +45,9 @@ func AccessTestDB(
 }
 
 func resetDatabase(db *sql.DB, dbMigrationRoot string, dbMigrationTool db.MigrationTool) error {
-	err := dbMigrationTool.MigrateUp(db, dbMigrationRoot)
-	if err != nil {
-		return err
-	}
-
-	return dbMigrationTool.MigrateDown(db, dbMigrationRoot)
+	_, err := db.Exec(`
+	DROP SCHEMA public CASCADE;
+	CREATE SCHEMA public;
+`)
+	return err
 }

--- a/fw/db/dbtest/access.go
+++ b/fw/db/dbtest/access.go
@@ -31,7 +31,7 @@ func AccessTestDB(
 
 	defer db.Close()
 
-	err = resetDatabase(db, dbMigrationRoot, dbMigrationTool)
+	err = resetDatabase(db)
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +44,7 @@ func AccessTestDB(
 	consumer(db)
 }
 
-func resetDatabase(db *sql.DB, dbMigrationRoot string, dbMigrationTool db.MigrationTool) error {
+func resetDatabase(db *sql.DB) error {
 	_, err := db.Exec(`
 	DROP SCHEMA public CASCADE;
 	CREATE SCHEMA public;


### PR DESCRIPTION
When resetting test DB, migration down sometimes causes conflicts due to change of primary key across migrations. Instead of migrate up and down, we are switching to directly drop all the tables in the DB.